### PR TITLE
Fix Authentik PostgreSQL validation issue

### DIFF
--- a/k8s/core/security/authentik/helmrelease.yaml
+++ b/k8s/core/security/authentik/helmrelease.yaml
@@ -62,3 +62,5 @@ spec:
     # Use external PostgreSQL instead of bundled one
     postgresql:
       enabled: false
+      auth:
+        password: "dummy-password-not-used"


### PR DESCRIPTION
## Problem
The Authentik HelmRelease was failing with PostgreSQL password validation errors, even though we're using an external PostgreSQL database with `postgresql.enabled: false`. The Bitnami PostgreSQL chart embedded in the Authentik chart was still requiring password validation.

## Solution
Added a dummy password for the embedded PostgreSQL configuration to satisfy the chart's validation requirements:

```yaml
postgresql:
  enabled: false
  auth:
    password: "dummy-password-not-used"
```

## Results
- ✅ Core-security kustomization now shows `Ready: True`
- ✅ Authentik HelmRelease shows `Ready: True` with "Helm upgrade succeeded"
- ✅ Authentik continues to work properly with external PostgreSQL
- ✅ No functional changes - dummy password is not used since embedded PostgreSQL is disabled

## Testing
- Verified kustomization reconciliation completes successfully
- Verified HelmRelease upgrade succeeds
- Verified Authentik pods remain healthy and accessible