### PR TITLE
Update Authentik from 2024.6.3 to 2025.6.3

### DIFF
--- a/k8s/core/security/authentik/helmrelease.yaml
+++ b/k8s/core/security/authentik/helmrelease.yaml
@@ -3,8 +3,9 @@ kind: HelmRelease
 metadata:
   name: authentik
   namespace: authentik
+  annotations:
+    reconcile.fluxcd.io/requestedAt: "2025-07-20T09:43:13-0700"
 spec:
-  suspend: true
   interval: 10m
   timeout: 10m
   install:
@@ -19,7 +20,7 @@ spec:
   chart:
     spec:
       chart: authentik
-      version: '2024.6.3'
+      version: '2025.6.3'
       sourceRef:
         kind: HelmRepository
         name: authentik

--- a/k8s/core/security/authentik/helmrelease.yaml
+++ b/k8s/core/security/authentik/helmrelease.yaml
@@ -4,6 +4,7 @@ metadata:
   name: authentik
   namespace: authentik
 spec:
+  suspend: true
   interval: 10m
   timeout: 10m
   install:


### PR DESCRIPTION
This PR updates the Authentik Helm chart version from 2024.6.3 to 2025.6.3. The update includes a reconcile annotation that was used during the reset process to ensure proper deployment.